### PR TITLE
feat(carepartner): Allow data retrieval as carepartner

### DIFF
--- a/carelink.js
+++ b/carelink.js
@@ -43,17 +43,10 @@ var Client = exports.Client = function (options) {
   var CARELINK_LOGIN_COOKIE = '_WL_AUTHCOOKIE_JSESSIONID';
   var user_agent_string = [software.name, software.version, software.bugs.url].join(' // ');
 
-  var carepartner = false;
-
+  var getCurrentRole = async function() {
+    return (await axiosInstance.get(CARELINK_ME_URL))?.data?.role?.toUpperCase();
+  }
   var carelinkJsonUrlNow = async function () {
-      var currentRole=(await axiosInstance.get(CARELINK_ME_URL))?.data?.role?.toUpperCase();
-      if(currentRole === "CARE_PARTNER_OUS" || currentRole === "CARE_PARTNER") {
-          var dataRetrievalUrl = (await axiosInstance.get(CARELINK_COUNTRY_SETTINGS_URL))?.data.blePereodicDataEndpoint;
-          if(dataRetrievalUrl) {
-              carepartner = true;
-              return dataRetrievalUrl;
-          }
-      }
       return (1 || CARELINK_EU ? CARELINKEU_JSON_BASE_URL : CARELINK_JSON_BASE_URL) + Date.now();
   };
     let requestCount = 0;
@@ -241,20 +234,27 @@ var Client = exports.Client = function (options) {
     }
 
     async function getConnectData() {
+      var currentRole=await getCurrentRole();
+
+      if(currentRole === "CARE_PARTNER_OUS" || currentRole === "CARE_PARTNER") {
+          var dataRetrievalUrl = (await axiosInstance.get(CARELINK_COUNTRY_SETTINGS_URL))?.data.blePereodicDataEndpoint;
+          if(dataRetrievalUrl) {
+                logger.log('GET data (as carepartner) ' + dataRetrievalUrl);
+                var body = {
+                    username: options.username,
+                    role: "carepartner"
+                };
+                return await axiosInstance.post(dataRetrievalUrl,body,{
+                    
+                });
+          } else {
+            throw new Error('Unable to retrieve data retrieval url for carepartner account');
+          }
+      } else {
         var url = await carelinkJsonUrlNow();
-        if(carepartner) {
-            logger.log('GET data (as carepartner) ' + url);
-            var body = {
-                username: options.username,
-                role: "carepartner"
-            };
-            return await axiosInstance.post(url,body,{
-                
-            });
-        } else {
-            logger.log('GET data ' + url);
-            return await axiosInstance.get(url);
-        }
+        logger.log('GET data ' + url);
+        return await axiosInstance.get(url);
+      }
     }
 
     async function checkLogin(relogin = false) {

--- a/carelink.js
+++ b/carelink.js
@@ -35,13 +35,25 @@ var Client = exports.Client = function (options) {
   var CARELINKEU_TOKEN_COOKIE = 'auth_tmp_token';
   var CARELINKEU_TOKENEXPIRE_COOKIE = 'c_token_valid_to';
 
+  var CARELINK_ME_URL = 'https://' + carelinkServerAddress + '/patient/users/me';
+  var CARELINK_COUNTRY_SETTINGS_URL = 'https://' + carelinkServerAddress + '/patient/countries/settings?countryCode='+(options.countrycode || DEFAULT_COUNTRYCODE)+'&language='+(options.lang || DEFAULT_LANGCODE);
   var CARELINK_SECURITY_URL = 'https://' + carelinkServerAddress + '/patient/j_security_check';
   var CARELINK_AFTER_LOGIN_URL = 'https://' + carelinkServerAddress + '/patient/main/login.do';
   var CARELINK_JSON_BASE_URL = 'https://' + carelinkServerAddress + '/patient/connect/ConnectViewerServlet?cpSerialNumber=NONE&msgType=last24hours&requestTime=';
   var CARELINK_LOGIN_COOKIE = '_WL_AUTHCOOKIE_JSESSIONID';
   var user_agent_string = [software.name, software.version, software.bugs.url].join(' // ');
 
-  var carelinkJsonUrlNow = function () {
+  var carepartner = false;
+
+  var carelinkJsonUrlNow = async function () {
+      var currentRole=(await axiosInstance.get(CARELINK_ME_URL))?.data?.role?.toUpperCase();
+      if(currentRole === "CARE_PARTNER_OUS" || currentRole === "CARE_PARTNER") {
+          var dataRetrievalUrl = (await axiosInstance.get(CARELINK_COUNTRY_SETTINGS_URL))?.data.blePereodicDataEndpoint;
+          if(dataRetrievalUrl) {
+              carepartner = true;
+              return dataRetrievalUrl;
+          }
+      }
       return (1 || CARELINK_EU ? CARELINKEU_JSON_BASE_URL : CARELINK_JSON_BASE_URL) + Date.now();
   };
     let requestCount = 0;
@@ -229,9 +241,20 @@ var Client = exports.Client = function (options) {
     }
 
     async function getConnectData() {
-        var url = carelinkJsonUrlNow();
-        logger.log('GET data ' + url);
-        return await axiosInstance.get(url);
+        var url = await carelinkJsonUrlNow();
+        if(carepartner) {
+            logger.log('GET data (as carepartner) ' + url);
+            var body = {
+                username: options.username,
+                role: "carepartner"
+            };
+            return await axiosInstance.post(url,body,{
+                
+            });
+        } else {
+            logger.log('GET data ' + url);
+            return await axiosInstance.get(url);
+        }
     }
 
     async function checkLogin(relogin = false) {


### PR DESCRIPTION
Having a go at fixing issue #11 

I am running this for the EU server.
The code checks if you are running as a carepartner (account used for Carelink Connect).
If so, it uses an alternative URL as discussed in issue #11 by @benceszasz to retrieve data.

I also had an issue with timezones but I don't think it is related to this issue but rather a new one.

Additional testing is much appreciated!