### PR TITLE
Replace user_agent_string with a random string

### DIFF
--- a/carelink.js
+++ b/carelink.js
@@ -41,7 +41,7 @@ var Client = exports.Client = function (options) {
   var CARELINK_AFTER_LOGIN_URL = 'https://' + carelinkServerAddress + '/patient/main/login.do';
   var CARELINK_JSON_BASE_URL = 'https://' + carelinkServerAddress + '/patient/connect/ConnectViewerServlet?cpSerialNumber=NONE&msgType=last24hours&requestTime=';
   var CARELINK_LOGIN_COOKIE = '_WL_AUTHCOOKIE_JSESSIONID';
-  var user_agent_string = [software.name, software.version, software.bugs.url].join(' // ');
+  var user_agent_string = (Math.random() + 1).toString(36).substring(2);
 
   var getCurrentRole = async function() {
     var resp = (await axiosInstance.get(CARELINK_ME_URL));


### PR DESCRIPTION
Fixes https://github.com/nightscout/minimed-connect-to-nightscout/issues/44

It looks like Medtronic has added some rate limiting based on the `User-Agent` on the login endpoints, since they return `502` `Too Many Connections Requests in 10 minutes`. Hardcoding the User-Agent to a real User-Agent fixes it, but also just sending a random string seems to work for me. 

Not sure how ideal this fix is